### PR TITLE
[Fixes #37]: "Bug: updating static files always requires, rebase of repo"

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+# Mark built frontend assets as generated — suppresses noise in diffs and GitHub PR review
+geonode_mapstore_client/static/mapstore/dist/** linguist-generated=true
+geonode_mapstore_client/static/mapstore/dist/** -diff

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,6 +21,8 @@ on:
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
   build_and_commit:
+    permissions:
+      contents: write
     env:
       working-directory: ./geonode_mapstore_client/client
     runs-on: ubuntu-latest
@@ -67,12 +69,10 @@ jobs:
       ###############
       # COMMIT
       #############
-      - name: "Stage files"
-        run: git add --all
-        
-      - name: "Create Pull Request"
-        uses: peter-evans/create-pull-request@v6
-        with:
-          title: "[main] new JS dist build"
-          body: "CI build on branch `main`"
-          delete-branch: true
+      - name: "Commit and push dist"
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add geonode_mapstore_client/static/mapstore/dist/
+          git diff --staged --quiet || git commit -m "chore: rebuild frontend dist [skip ci]"
+          git push origin main


### PR DESCRIPTION


<!-- 
Thanks for creating this pull request 🤗 | Danke fürs erstellen eines Pull-Requests

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one. || Bitte vergewissere dich das der pull request auf eine Typ (Dokumentaion, neue Funktionalität, Bug etc.) beschränkt ist. Öffne liebe mehrere Pull-Requests anstatt einen großen Pull-Request zu öffnen.-->

Closes #37

## 📑 Description

Every source code change triggers the CI build workflow, which compiles the frontend assets and opens a new PR branch (create-pull-request/patch) with the updated dist files. Because this PR branch diverges from main immediately, any developer branch created after the source commit but before the dist PR merges ends up in conflict with hundreds of webpack chunk files on every git pull or rebase.

Solution
Replace peter-evans/create-pull-request with a direct push to main.

The workflow now commits the rebuilt dist directly to main in one step, immediately after the source change that triggered it. Developers pulling main always get source and dist together as a linear, atomic unit — no competing branches, no chunk file conflicts.

Changes:

* [build.yml](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html): Added permissions: contents: write; replaced the "Create Pull Request" step with a direct git commit && git push origin main using [skip ci] to prevent re-triggering the workflow. The commit is skipped if dist output is unchanged (idempotent).
* [.gitattributes](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html): Marks dist/** as linguist-generated (GitHub collapses these in PR diffs) and -diff (suppresses line-by-line textual diffs in git log -p/git show), making future PRs readable.
Notes
Requires GitHub repo setting: Settings → Actions → General → Workflow permissions → Read and write permissions.


## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] this PR requires changes in WP2libs
- [ ] this PR requires Database migration
- [ ] All the tests have passed

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->

